### PR TITLE
Fixed ryu-manager command by downgrading eventlet

### DIFF
--- a/debian10/sdn/Dockerfile
+++ b/debian10/sdn/Dockerfile
@@ -15,6 +15,7 @@ RUN apt install -y \
 	python3-pip \
 	zlib1g-dev
 
+RUN python3 -m pip install --no-cache-dir eventlet==0.30.2
 RUN python3 -m pip install --no-cache-dir ryu
 
 RUN /usr/bin/ovsdb-tool create /etc/openvswitch/conf.db

--- a/debian9/sdn/Dockerfile
+++ b/debian9/sdn/Dockerfile
@@ -21,7 +21,8 @@ RUN wget -O openvswitch-switch.deb http://ftp.it.debian.org/debian/pool/main/o/o
     apt install -y ./openvswitch-switch.deb && \
     rm openvswitch-switch.deb
 
-RUN python3 -m pip install --no-cache-dir --upgrade pip 
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+RUN python3 -m pip install --no-cache-dir eventlet==0.30.2
 RUN python3 -m pip install --no-cache-dir pbr wrapt
 RUN python3 -m pip install --no-cache-dir ryu
 


### PR DESCRIPTION
As of now, ryu-manager will crash with an ImportError due to changes in the eventlet API. This pull request installs a prior, compatible version to fix this problem