### PR TITLE
Add `kathara/bind` image with multiple tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ p4-multi: create-builder base-multi
 	$(BUILDX) -t kathara/p4 --push p4
 
 bind-multi\:%: create-builder
-	$(BUILDX) -t kathara/bind:$* bind/$*
+	$(BUILDX) -t kathara/bind:$* --push bind/$*
 
 create-builder:
 	docker buildx create --name kat-builder --use

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ BUILDX=docker buildx build --platform linux/amd64,linux/arm64
 
 .PHONY: base quagga frr bird openbgpd krill routinator rpki-client rift-python sdn p4 all pushall all-multi create-builder base-multi quagga-multi frr-multi bird-multi openbgpd-multi krill-multi routinator-multi rpki-client-multi rift-python-multi sdn-multi p4-multi delete-builder
 
-all: base quagga frr bird openbgpd krill rpki-client routinator rift-python sdn p4 bind\:9.18 bind\:9.16
-all-multi: create-builder base-multi quagga-multi frr-multi bird-multi openbgpd-multi krill-multi routinator-multi rpki-client-multi rift-python-multi sdn-multi p4-multi bind-multi\:9.18 bind-multi\:9.16 delete-builder
+all: base quagga frr bird openbgpd krill rpki-client routinator rift-python sdn p4 bind\:9.18 bind\:9.16 bind\:9.11
+all-multi: create-builder base-multi quagga-multi frr-multi bird-multi openbgpd-multi krill-multi routinator-multi rpki-client-multi rift-python-multi sdn-multi p4-multi bind-multi\:9.18 bind-multi\:9.16 bind-multi\:9.11 delete-builder
 
 pushall:
 	docker push kathara/base
@@ -19,6 +19,7 @@ pushall:
 	docker push kathara/p4
 	docker push kathara/bind:9.18
 	docker push kathara/bind:9.16
+	docker push kathara/bind:9.11
 
 base:
 	docker build -t kathara/base base

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ BUILDX=docker buildx build --platform linux/amd64,linux/arm64
 
 .PHONY: base quagga frr bird openbgpd krill routinator rpki-client rift-python sdn p4 all pushall all-multi create-builder base-multi quagga-multi frr-multi bird-multi openbgpd-multi krill-multi routinator-multi rpki-client-multi rift-python-multi sdn-multi p4-multi delete-builder
 
-all: base quagga frr bird openbgpd krill rpki-client routinator rift-python sdn p4
-all-multi: create-builder base-multi quagga-multi frr-multi bird-multi openbgpd-multi krill-multi routinator-multi rpki-client-multi rift-python-multi sdn-multi p4-multi delete-builder
+all: base quagga frr bird openbgpd krill rpki-client routinator rift-python sdn p4 bind\:9.18 bind\:9.16
+all-multi: create-builder base-multi quagga-multi frr-multi bird-multi openbgpd-multi krill-multi routinator-multi rpki-client-multi rift-python-multi sdn-multi p4-multi bind-multi\:9.18 bind-multi\:9.16 delete-builder
 
 pushall:
 	docker push kathara/base
@@ -17,6 +17,8 @@ pushall:
 	docker push kathara/rift-python
 	docker push kathara/sdn
 	docker push kathara/p4
+	docker push kathara/bind:9.18
+	docker push kathara/bind:9.16
 
 base:
 	docker build -t kathara/base base
@@ -51,6 +53,9 @@ sdn: base
 p4: base
 	docker build -t kathara/p4 p4
 
+bind\:%:
+	docker build -t kathara/bind:$* bind/$*
+
 base-multi: create-builder
 	$(BUILDX) -t kathara/base --push base
 
@@ -83,6 +88,9 @@ sdn-multi: create-builder base-multi
 
 p4-multi: create-builder base-multi
 	$(BUILDX) -t kathara/p4 --push p4
+
+bind-multi\:%: create-builder
+	$(BUILDX) -t kathara/bind:$* bind/$*
 
 create-builder:
 	docker buildx create --name kat-builder --use

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains `Dockerfile`s used to build Kathará images. A list of the Docker images we provide can be found at [this page](https://hub.docker.com/u/kathara/) in the Docker Hub.
 Images are built both with `docker build` and with `docker buildx` for multi-architecture support.
-Currently our images are based on Debian 11 and are compiled for `amd64` and `arm64`.
+Currently, our images are based on Debian 12 and are compiled for `amd64` and `arm64`.
 If you need images based on other Linux distributions, feel free to create a PR with other Dockerfiles.
 
 Currently available images are:
@@ -17,7 +17,7 @@ Currently available images are:
 - `kathara/rift-python`: extends the base image adding [Routing In Fat Trees (RIFT) Python Implementation](https://github.com/brunorijsman/rift-python).
 - `kathara/sdn`: extends the base image adding [OpenVSwitch](https://www.openvswitch.org/) and [Ryu SDN controller](https://osrg.github.io/ryu/).
 - `kathara/p4`: extends the base image adding [Behavioral Model (bmv2)](https://github.com/p4lang/behavioral-model) to compile and run P4-compliant programmable switches.
-- `kathara/bind`: a minimal image including just bind (lighter than `kathara/base`). Supports bind 9.18 (latest) and 9.16 (latest not forcing DNSSEC).
+- `kathara/bind`: a minimal image including just bind (lighter than `kathara/base`). Supports bind 9.18 (latest), 9.16 (latest not forcing DNSSEC) and 9.11.
 
 
 ## Building from source

--- a/README.md
+++ b/README.md
@@ -17,11 +17,16 @@ Currently available images are:
 - `kathara/rift-python`: extends the base image adding [Routing In Fat Trees (RIFT) Python Implementation](https://github.com/brunorijsman/rift-python).
 - `kathara/sdn`: extends the base image adding [OpenVSwitch](https://www.openvswitch.org/) and [Ryu SDN controller](https://osrg.github.io/ryu/).
 - `kathara/p4`: extends the base image adding [Behavioral Model (bmv2)](https://github.com/p4lang/behavioral-model) to compile and run P4-compliant programmable switches.
+- `kathara/bind`: a minimal image including just bind (lighter than `kathara/base`). Supports bind 9.18 (latest) and 9.16 (latest not forcing DNSSEC).
 
 
 ## Building from source
 To build an image from source, run `make <image_name>` to build for the current architecture.
+
+**Beware**: images which support multiple versions can be build running `make <image_name>:<version>` (e.g., `make bind:9.16`).
+
 To build an image with `docker buildx` for multi-architectures use the command `make <image_name>-multi`.
+
 **Beware**: building images with `docker buildx` automatically push the images on the Kathará Docker Hub. If you are not allowed to push, change the `Makefile` before running `make`.
 
 Example: `make quagga` or `make quagga-multi`.

--- a/bind/9.11/.bashrc
+++ b/bind/9.11/.bashrc
@@ -1,0 +1,101 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+
+# If not running interactively, don't do anything
+[ -z "$PS1" ] && return
+
+# don't put duplicate lines in the history. See bash(1) for more options
+# ... or force ignoredups and ignorespace
+HISTCONTROL=ignoredups:ignorespace
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+#force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+	# We have color support; assume it's compliant with Ecma-48
+	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+	# a case would tend to support setf rather than setaf.)
+	color_prompt=yes
+    else
+	color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+fi
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    #alias dir='dir --color=auto'
+    #alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Alias definitions.
+# You may want to put all your additions into a separate file like
+# ~/.bash_aliases, instead of adding them here directly.
+# See /usr/share/doc/bash-doc/examples in the bash-doc package.
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+#if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
+#    . /etc/bash_completion
+#fi
+
+export VTYSH_PAGER="less -EFX"

--- a/bind/9.11/Dockerfile
+++ b/bind/9.11/Dockerfile
@@ -21,7 +21,7 @@ RUN apt install -y \
 	iputils-ping \
 	less \
 	links \
-    man-db \
+	man-db \
 	nano \
 	net-tools \
 	netbase \
@@ -56,8 +56,6 @@ RUN FILE_NAME=`wget -q -O - https://mirrors.edge.kernel.org/pub/linux/utils/net/
 	cd .. && \
 	rm -r $FILE_NAME && \
 	rm $FILE_NAME.tar.xz
-
-RUN ln -s /etc/init.d/named /etc/init.d/bind
 
 RUN wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl && \
 	chmod +x /usr/local/bin/systemctl

--- a/bind/9.11/Dockerfile
+++ b/bind/9.11/Dockerfile
@@ -1,0 +1,73 @@
+FROM debian:10
+LABEL org.opencontainers.image.authors="Kathara Team <contact@kathara.org>"
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ARG DEBIAN_FRONTEND="noninteractive"
+RUN apt update
+RUN apt upgrade -y
+RUN apt install -y \
+	apt-utils \
+	apt-transport-https \
+	bind9 \
+	bison \
+	build-essential \
+	curl \
+	dnsutils \
+	ethtool \
+	flex \
+	iptables \
+	iputils-ping \
+	less \
+	links \
+    man-db \
+	nano \
+	net-tools \
+	netbase \
+	netcat-openbsd \
+	openssh-client \
+	openssh-server \
+	openssh-sftp-server \
+	openssl \
+	rsync \
+	screen \
+	sed \
+	tar \
+	tcpdump \
+	telnet \
+	tmux \
+	traceroute \
+	wget \
+	vim
+
+WORKDIR /tmp
+
+RUN FILE_NAME=`wget -q -O - https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/ | \
+	tac | \
+	grep -m 1 -o "iproute2-6[\.0-9]*[0-9]" | \
+	head -n 1` && \
+	wget -q https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/$FILE_NAME.tar.xz && \
+	tar xf $FILE_NAME.tar.xz && \
+	cd $FILE_NAME && \
+	./configure && \
+	make -j$(nproc --ignore=4) && \
+	make install && \
+	cd .. && \
+	rm -r $FILE_NAME && \
+	rm $FILE_NAME.tar.xz
+
+RUN ln -s /etc/init.d/named /etc/init.d/bind
+
+RUN wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl && \
+	chmod +x /usr/local/bin/systemctl
+
+COPY .bashrc /root/.bashrc
+
+RUN apt clean && \
+	rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
+
+WORKDIR /
+
+VOLUME /hosthome
+VOLUME /shared

--- a/bind/9.16/.bashrc
+++ b/bind/9.16/.bashrc
@@ -1,0 +1,101 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+
+# If not running interactively, don't do anything
+[ -z "$PS1" ] && return
+
+# don't put duplicate lines in the history. See bash(1) for more options
+# ... or force ignoredups and ignorespace
+HISTCONTROL=ignoredups:ignorespace
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+#force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+	# We have color support; assume it's compliant with Ecma-48
+	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+	# a case would tend to support setf rather than setaf.)
+	color_prompt=yes
+    else
+	color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+fi
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    #alias dir='dir --color=auto'
+    #alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Alias definitions.
+# You may want to put all your additions into a separate file like
+# ~/.bash_aliases, instead of adding them here directly.
+# See /usr/share/doc/bash-doc/examples in the bash-doc package.
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+#if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
+#    . /etc/bash_completion
+#fi
+
+export VTYSH_PAGER="less -EFX"

--- a/bind/9.16/Dockerfile
+++ b/bind/9.16/Dockerfile
@@ -21,7 +21,7 @@ RUN apt install -y \
 	iputils-ping \
 	less \
 	links \
-    man-db \
+	man-db \
 	nano \
 	net-tools \
 	netbase \
@@ -56,8 +56,6 @@ RUN FILE_NAME=`wget -q -O - https://mirrors.edge.kernel.org/pub/linux/utils/net/
 	cd .. && \
 	rm -r $FILE_NAME && \
 	rm $FILE_NAME.tar.xz
-
-RUN ln -s /etc/init.d/named /etc/init.d/bind
 
 RUN wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl && \
 	chmod +x /usr/local/bin/systemctl

--- a/bind/9.16/Dockerfile
+++ b/bind/9.16/Dockerfile
@@ -1,0 +1,73 @@
+FROM debian:11
+LABEL org.opencontainers.image.authors="Kathara Team <contact@kathara.org>"
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ARG DEBIAN_FRONTEND="noninteractive"
+RUN apt update
+RUN apt upgrade -y
+RUN apt install -y \
+	apt-utils \
+	apt-transport-https \
+	bind9 \
+	bison \
+	build-essential \
+	curl \
+	dnsutils \
+	ethtool \
+	flex \
+	iptables \
+	iputils-ping \
+	less \
+	links \
+    man-db \
+	nano \
+	net-tools \
+	netbase \
+	netcat-openbsd \
+	openssh-client \
+	openssh-server \
+	openssh-sftp-server \
+	openssl \
+	rsync \
+	screen \
+	sed \
+	tar \
+	tcpdump \
+	telnet \
+	tmux \
+	traceroute \
+	wget \
+	vim
+
+WORKDIR /tmp
+
+RUN FILE_NAME=`wget -q -O - https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/ | \
+	tac | \
+	grep -m 1 -o "iproute2-6[\.0-9]*[0-9]" | \
+	head -n 1` && \
+	wget -q https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/$FILE_NAME.tar.xz && \
+	tar xf $FILE_NAME.tar.xz && \
+	cd $FILE_NAME && \
+	./configure && \
+	make -j$(nproc --ignore=4) && \
+	make install && \
+	cd .. && \
+	rm -r $FILE_NAME && \
+	rm $FILE_NAME.tar.xz
+
+RUN ln -s /etc/init.d/named /etc/init.d/bind
+
+RUN wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl && \
+	chmod +x /usr/local/bin/systemctl
+
+COPY .bashrc /root/.bashrc
+
+RUN apt clean && \
+	rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
+
+WORKDIR /
+
+VOLUME /hosthome
+VOLUME /shared

--- a/bind/9.18/.bashrc
+++ b/bind/9.18/.bashrc
@@ -1,0 +1,101 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+
+# If not running interactively, don't do anything
+[ -z "$PS1" ] && return
+
+# don't put duplicate lines in the history. See bash(1) for more options
+# ... or force ignoredups and ignorespace
+HISTCONTROL=ignoredups:ignorespace
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+#force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+	# We have color support; assume it's compliant with Ecma-48
+	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+	# a case would tend to support setf rather than setaf.)
+	color_prompt=yes
+    else
+	color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+fi
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    #alias dir='dir --color=auto'
+    #alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Alias definitions.
+# You may want to put all your additions into a separate file like
+# ~/.bash_aliases, instead of adding them here directly.
+# See /usr/share/doc/bash-doc/examples in the bash-doc package.
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+#if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
+#    . /etc/bash_completion
+#fi
+
+export VTYSH_PAGER="less -EFX"

--- a/bind/9.18/Dockerfile
+++ b/bind/9.18/Dockerfile
@@ -21,7 +21,7 @@ RUN apt install -y \
 	iputils-ping \
 	less \
 	links \
-    man-db \
+	man-db \
 	nano \
 	net-tools \
 	netbase \
@@ -56,8 +56,6 @@ RUN FILE_NAME=`wget -q -O - https://mirrors.edge.kernel.org/pub/linux/utils/net/
 	cd .. && \
 	rm -r $FILE_NAME && \
 	rm $FILE_NAME.tar.xz
-
-RUN ln -s /etc/init.d/named /etc/init.d/bind
 
 RUN wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl && \
 	chmod +x /usr/local/bin/systemctl

--- a/bind/9.18/Dockerfile
+++ b/bind/9.18/Dockerfile
@@ -1,0 +1,73 @@
+FROM debian:12
+LABEL org.opencontainers.image.authors="Kathara Team <contact@kathara.org>"
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ARG DEBIAN_FRONTEND="noninteractive"
+RUN apt update
+RUN apt upgrade -y
+RUN apt install -y \
+	apt-utils \
+	apt-transport-https \
+	bind9 \
+	bison \
+	build-essential \
+	curl \
+	dnsutils \
+	ethtool \
+	flex \
+	iptables \
+	iputils-ping \
+	less \
+	links \
+    man-db \
+	nano \
+	net-tools \
+	netbase \
+	netcat-openbsd \
+	openssh-client \
+	openssh-server \
+	openssh-sftp-server \
+	openssl \
+	rsync \
+	screen \
+	sed \
+	tar \
+	tcpdump \
+	telnet \
+	tmux \
+	traceroute \
+	wget \
+	vim
+
+WORKDIR /tmp
+
+RUN FILE_NAME=`wget -q -O - https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/ | \
+	tac | \
+	grep -m 1 -o "iproute2-6[\.0-9]*[0-9]" | \
+	head -n 1` && \
+	wget -q https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/$FILE_NAME.tar.xz && \
+	tar xf $FILE_NAME.tar.xz && \
+	cd $FILE_NAME && \
+	./configure && \
+	make -j$(nproc --ignore=4) && \
+	make install && \
+	cd .. && \
+	rm -r $FILE_NAME && \
+	rm $FILE_NAME.tar.xz
+
+RUN ln -s /etc/init.d/named /etc/init.d/bind
+
+RUN wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl && \
+	chmod +x /usr/local/bin/systemctl
+
+COPY .bashrc /root/.bashrc
+
+RUN apt clean && \
+	rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
+
+WORKDIR /
+
+VOLUME /hosthome
+VOLUME /shared


### PR DESCRIPTION
This Pull Request introduces the `kathara/bind` Docker image. The image supports multiple tags based on different bind versions:

- `kathara/bind:9.18` (based on Debian 12)
- `kathara/bind:9.16` (based on Debian 11)
- `kathara/bind:9.11` (based on Debian 10)

These tags provide users with the flexibility to choose a specific version based on their requirements. 