### PR TITLE
Adding POX Docker Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ rift-python: base
 sdn: base
 	docker build -t kathara/sdn sdn
 
+pox: base
+	docker build -t kathara/pox pox
+
 p4: base
 	docker build -t kathara/p4 p4
 
@@ -80,6 +83,9 @@ rift-python-multi: create-builder base-multi
 
 sdn-multi: create-builder base-multi
 	$(BUILDX) -t kathara/sdn --push sdn
+
+pox-multi: create-builder base-multi
+	$(BUILDX) -t kathara/pox --push pox
 
 p4-multi: create-builder base-multi
 	$(BUILDX) -t kathara/p4 --push p4

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently available images are:
 - `kathara/rift-python`: extends the base image adding [Routing In Fat Trees (RIFT) Python Implementation](https://github.com/brunorijsman/rift-python).
 - `kathara/sdn`: extends the base image adding [OpenVSwitch](https://www.openvswitch.org/) and [Ryu SDN controller](https://osrg.github.io/ryu/).
 - `kathara/p4`: extends the base image adding [Behavioral Model (bmv2)](https://github.com/p4lang/behavioral-model) to compile and run P4-compliant programmable switches.
+- `kathara/pox`: extends the base image adding [POX](https://github.com/noxrepo/pox) (Python based SDN Controller) and python3-networkx.
 
 
 ## Building from source

--- a/pox/Dockerfile
+++ b/pox/Dockerfile
@@ -24,3 +24,10 @@ RUN python3.9 -m pip install networkx
 # Clone and set permissions for pox
 RUN git clone https://github.com/noxrepo/pox.git && \
     chmod +x /pox/pox.py
+
+# Remove not needed libraries
+RUN apt remove -y zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev
+
+# Clean up caches/other
+RUN apt clean && \
+    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*

--- a/pox/Dockerfile
+++ b/pox/Dockerfile
@@ -1,0 +1,24 @@
+FROM kathara/base
+LABEL org.opencontainers.image.authors="Kathara Team <contact@kathara.org>"
+
+ARG DEBIAN_FRONTEND="noninteractive"
+RUN apt clean all
+RUN apt update
+RUN apt install -y zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev
+
+# Install Python 3.9
+RUN wget https://www.python.org/ftp/python/3.9.17/Python-3.9.17.tar.xz && \
+    tar -xf Python-3.9.17.tar.xz && \
+    mv Python-3.9.17 /usr/local/share/python3.9 && \
+    cd /usr/local/share/python3.9 && \
+    ./configure --enable-optimizations --enable-shared && \
+    make -j 8 build_all && \
+    make -j 8 altinstall && \
+    ldconfig /usr/local/share/python3.9
+
+# Install Python3-networkx
+RUN python3.9 -m pip install networkx
+
+# Clone and set permissions for pox
+RUN git clone https://github.com/noxrepo/pox.git && \
+    chmod +x /pox/pox.py

--- a/pox/Dockerfile
+++ b/pox/Dockerfile
@@ -16,6 +16,8 @@ RUN wget https://www.python.org/ftp/python/3.9.17/Python-3.9.17.tar.xz && \
     make -j 8 altinstall && \
     ldconfig /usr/local/share/python3.9
 
+RUN rm Python-3.9.17.tar.xz
+
 # Install Python3-networkx
 RUN python3.9 -m pip install networkx
 


### PR DESCRIPTION
Hi,

Here it is a **Docker POX image**, to allow using POX without importing POX as a Git submodule. The new image is based on the kathara/base image.

The Docker image is needed for the sdn-openflow labs (located in the main labs directory).