### PR TITLE
Add SCION docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 BUILDX=docker buildx build --platform linux/amd64,linux/arm64
 
-.PHONY: base quagga frr bird openbgpd krill routinator rpki-client rift-python sdn p4 all pushall all-multi create-builder base-multi quagga-multi frr-multi bird-multi openbgpd-multi krill-multi routinator-multi rpki-client-multi rift-python-multi sdn-multi p4-multi delete-builder
+.PHONY: base quagga frr bird openbgpd krill routinator rpki-client rift-python sdn p4 scion all pushall all-multi create-builder base-multi quagga-multi frr-multi bird-multi openbgpd-multi krill-multi routinator-multi rpki-client-multi rift-python-multi sdn-multi p4-multi scion-multi delete-builder
 
-all: base quagga frr bird openbgpd krill rpki-client routinator rift-python sdn p4
-all-multi: create-builder base-multi quagga-multi frr-multi bird-multi openbgpd-multi krill-multi routinator-multi rpki-client-multi rift-python-multi sdn-multi p4-multi delete-builder
+all: base quagga frr bird openbgpd krill rpki-client routinator rift-python sdn p4 scion
+all-multi: create-builder base-multi quagga-multi frr-multi bird-multi openbgpd-multi krill-multi routinator-multi rpki-client-multi rift-python-multi sdn-multi p4-multi scion-multi delete-builder
 
 pushall:
 	docker push kathara/base
@@ -17,6 +17,7 @@ pushall:
 	docker push kathara/rift-python
 	docker push kathara/sdn
 	docker push kathara/p4
+	docker push kathara/scion
 
 base:
 	docker build -t kathara/base base
@@ -54,6 +55,9 @@ pox: base
 p4: base
 	docker build -t kathara/p4 p4
 
+scion: base
+	docker build -t kathara/scion scion
+
 base-multi: create-builder
 	$(BUILDX) -t kathara/base --push base
 
@@ -89,6 +93,9 @@ pox-multi: create-builder base-multi
 
 p4-multi: create-builder base-multi
 	$(BUILDX) -t kathara/p4 --push p4
+
+scion-multi: create-builder
+	$(BUILDX) -t kathara/scion --push scion
 
 create-builder:
 	docker buildx create --name kat-builder --use

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Currently available images are:
 - `kathara/sdn`: extends the base image adding [OpenVSwitch](https://www.openvswitch.org/) and [Ryu SDN controller](https://osrg.github.io/ryu/).
 - `kathara/p4`: extends the base image adding [Behavioral Model (bmv2)](https://github.com/p4lang/behavioral-model) to compile and run P4-compliant programmable switches.
 - `kathara/pox`: extends the base image adding [POX](https://github.com/noxrepo/pox) (Python based SDN Controller) and python3-networkx.
+- `kathara/scion`: extends the base image adding [SCION](https://scion-architecture.net) (Scalability, Control, and Isolation On Next-Generation Networks).
 
 
 ## Building from source

--- a/scion/Dockerfile
+++ b/scion/Dockerfile
@@ -7,13 +7,12 @@ ARG TARGETARCH
 RUN cd /tmp/ && \
     wget https://github.com/scionproto/scion/releases/download/v0.12.0/scion_0.12.0_deb_$TARGETARCH.tar.gz && \
     tar xfz scion_0.12.0_deb_$TARGETARCH.tar.gz && \
-    apt install ./scion*.deb
+    apt install ./scion*.deb && \
+    apt clean && \
+    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 
 # Strip templating from systemd service files, systemd-replacement-script does not support it
 RUN mv /usr/lib/systemd/system/scion-router\@.service /usr/lib/systemd/system/scion-router.service && \
     sed -i 's/%i/br/g' /usr/lib/systemd/system/scion-router.service && \
     mv /usr/lib/systemd/system/scion-control\@.service /usr/lib/systemd/system/scion-control.service && \
     sed -i 's/%i/cs/g' /usr/lib/systemd/system/scion-control.service
-
-RUN apt clean && \
-    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*

--- a/scion/Dockerfile
+++ b/scion/Dockerfile
@@ -1,0 +1,19 @@
+FROM kathara/base
+LABEL org.opencontainers.image.authors="Network Security Group, ETH Zurich <netsec.ethz.ch>"
+
+# Install SCION from GitHub release
+ARG DEBIAN_FRONTEND="noninteractive"
+ARG TARGETARCH
+RUN cd /tmp/ && \
+    wget https://github.com/scionproto/scion/releases/download/v0.12.0/scion_0.12.0_deb_$TARGETARCH.tar.gz && \
+    tar xfz scion_0.12.0_deb_$TARGETARCH.tar.gz && \
+    apt install ./scion*.deb
+
+# Strip templating from systemd service files, systemd-replacement-script does not support it
+RUN mv /usr/lib/systemd/system/scion-router\@.service /usr/lib/systemd/system/scion-router.service && \
+    sed -i 's/%i/br/g' /usr/lib/systemd/system/scion-router.service && \
+    mv /usr/lib/systemd/system/scion-control\@.service /usr/lib/systemd/system/scion-control.service && \
+    sed -i 's/%i/cs/g' /usr/lib/systemd/system/scion-control.service
+
+RUN apt clean && \
+    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*


### PR DESCRIPTION
Hi,

This PR introduces a SCION (https://github.com/scionproto/scion) image for use in Kathara labs and updates the documentation accordingly.
This image will be used in the ETH Computer Networks course in the coming semester. A corresponding lab will be available soon in the labs repository.