### PR TITLE
Add dnsmasq to base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -21,6 +21,7 @@ RUN apt install -y \
     build-essential \
     curl \
     diffutils \
+    dnsmasq \
     dnsutils \
     dublin-traceroute  \
     ethtool \


### PR DESCRIPTION
## Summary
- Add `dnsmasq` package to the base image

For our Computer Networks exercises, we want to include a home network setup where we also show the basics of DNS. Given the prevalence of dnsmasq in consumer-grade routers, I think it's a good fit to include in the base image.